### PR TITLE
Fix plugin workflow for missing lock file

### DIFF
--- a/.github/workflows/publish-plugin.yml
+++ b/.github/workflows/publish-plugin.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Build Windy plugin
         working-directory: knmi-windy-plugin
         run: |
-          npm ci
+          npm install
           npm run build
 
       # 4. Publish to Windy’s plugin registry


### PR DESCRIPTION
## Summary
- use `npm install` for plugin build workflow instead of `npm ci`

## Testing
- `npm run build` in `knmi-windy-plugin`

------
https://chatgpt.com/codex/tasks/task_e_686d25f99cc4832cb92a5e35528958ec