### PR TITLE
Add instructions for building Windy plugin

### DIFF
--- a/publish_plugin.sh
+++ b/publish_plugin.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${WINDY_API_KEY:-}" ]; then
+    echo "WINDY_API_KEY not set" >&2
+    exit 1
+fi
+
+repo_name="artis-byte/NL-solar"
+repo_owner="artis-byte"
+repo_root=$(pwd)
+commit_sha=$(git rev-parse HEAD)
+
+npm --version >/dev/null
+cd knmi-windy-plugin
+npm install
+npm run build
+
+cd dist
+printf '{"repositoryName":"%s","commitSha":"%s","repositoryOwner":"%s"}\n' "$repo_name" "$commit_sha" "$repo_owner" > /tmp/plugin-info.json
+mv plugin.json /tmp/orig-plugin.json
+jq -s '.[0] * .[1]' /tmp/orig-plugin.json /tmp/plugin-info.json > plugin.json
+
+tar cf "$repo_root/plugin.tar" .
+
+# update docs so plugin.js can be loaded from GitHub
+cp plugin.* screenshot.jpg "$repo_root/docs/"
+
+curl -X POST 'https://node.windy.com/plugins/v1.0/upload' \
+     -H "x-windy-api-key: $WINDY_API_KEY" \
+     -F "plugin_archive=@$repo_root/plugin.tar"


### PR DESCRIPTION
## Summary
- clarify plugin build steps in README
- copy built files to `docs/` in publish script

## Testing
- `python -m py_compile fetch_coordinates.py src/*.py`
- `cd knmi-windy-plugin && npm run build`
- `WINDY_API_KEY=badkey ./publish_plugin.sh` (fails with 401)


------
https://chatgpt.com/codex/tasks/task_e_686d2887fd44832caedcedb93dc4f16c