### PR TITLE
Improve plugin build docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,39 @@ python src/regions.py --parks data/parks_geocoded.csv \
 The generated `parks.geojson` and `regions_capacity.geojson` can be uploaded to the [Windy uploader](https://windy.com/uploader) for visualisation.
 
 The geocoding script stores responses in `data/nominatim_cache.sqlite` so that reruns are faster and gentler on the API. This cache file is ignored by Git.
+
+## Windy plugin
+
+This repository contains a Windy plugin in `knmi-windy-plugin`.
+Make sure you run the commands from the repository root (you can use
+`cd $(git rev-parse --show-toplevel)` to be certain). To build and upload it
+manually:
+
+```bash
+cd knmi-windy-plugin
+npm install
+npm run build  # creates knmi-windy-plugin/dist/
+
+cd dist
+# plugin.json is located in this directory after the build
+commit_sha=$(git rev-parse HEAD)
+printf '{"repositoryName":"artis-byte/NL-solar","commitSha":"%s","repositoryOwner":"artis-byte"}\n' "$commit_sha" > /tmp/plugin-info.json
+cp plugin.json /tmp/orig-plugin.json
+jq -s '.[0] * .[1]' /tmp/orig-plugin.json /tmp/plugin-info.json > plugin.json
+
+tar cf ../plugin.tar .
+
+# Optionally update the version served from GitHub Pages
+cp plugin.* screenshot.jpg ../../docs/
+
+curl -X POST 'https://node.windy.com/plugins/v1.0/upload' \
+     -H "x-windy-api-key: $WINDY_API_KEY" \
+     -F "plugin_archive=@../plugin.tar"
+```
+
+The built plugin files are also committed under `docs/` so they can be loaded by Windy at:
+
+```
+https://raw.githubusercontent.com/artis-byte/NL-solar/main/docs/plugin.js
+```
+You can also run `./publish_plugin.sh` to automate these steps.

--- a/publish_plugin.sh
+++ b/publish_plugin.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${WINDY_API_KEY:-}" ]; then
+    echo "WINDY_API_KEY not set" >&2
+    exit 1
+fi
+
+repo_name="artis-byte/NL-solar"
+repo_owner="artis-byte"
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+commit_sha=$(git rev-parse HEAD)
+
+npm --version >/dev/null
+cd knmi-windy-plugin
+npm install
+npm run build
+
+cd dist
+# plugin.json is produced inside this directory
+printf '{"repositoryName":"%s","commitSha":"%s","repositoryOwner":"%s"}\n' "$repo_name" "$commit_sha" "$repo_owner" > /tmp/plugin-info.json
+cp plugin.json /tmp/orig-plugin.json
+jq -s '.[0] * .[1]' /tmp/orig-plugin.json /tmp/plugin-info.json > plugin.json
+
+tar cf "$repo_root/plugin.tar" .
+
+# update docs so plugin.js can be loaded from GitHub
+cp plugin.* screenshot.jpg "$repo_root/docs/"
+
+curl -X POST 'https://node.windy.com/plugins/v1.0/upload' \
+     -H "x-windy-api-key: $WINDY_API_KEY" \
+     -F "plugin_archive=@$repo_root/plugin.tar"


### PR DESCRIPTION
## Summary
- clarify that plugin commands should run from repo root
- note location of `plugin.json`
- copy instead of move in publish script

## Testing
- `python -m py_compile fetch_coordinates.py src/*.py`
- `cd knmi-windy-plugin && npm run build`
- `WINDY_API_KEY=badkey ./publish_plugin.sh` (fails with 401)


------
https://chatgpt.com/codex/tasks/task_e_686d2887fd44832caedcedb93dc4f16c