### PR TITLE
Fix plugin publishing helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ The built plugin files are also committed under `docs/` so they can be loaded by
 ```
 https://raw.githubusercontent.com/artis-byte/NL-solar/main/docs/plugin.js
 ```
-You can also run `./publish_plugin.sh` to automate these steps.
+You can also run `./publish_plugin.sh` from the repository root to automate these steps. The script requires `WINDY_API_KEY` to be set.

--- a/publish_plugin.sh
+++ b/publish_plugin.sh
@@ -10,18 +10,20 @@ repo_name="artis-byte/NL-solar"
 repo_owner="artis-byte"
 commit_sha=$(git rev-parse HEAD)
 
-cd knmi-windy-plugin
-npm install
-npm run build
+(
+    cd knmi-windy-plugin
+    npm install
+    npm run build
 
-cd dist
-printf '{"repositoryName":"%s","commitSha":"%s","repositoryOwner":"%s"}\n' "$repo_name" "$commit_sha" "$repo_owner" > /tmp/plugin-info.json
-mv plugin.json /tmp/orig-plugin.json
-jq -s '.[0] * .[1]' /tmp/orig-plugin.json /tmp/plugin-info.json > plugin.json
+    cd dist
+    printf '{"repositoryName":"%s","commitSha":"%s","repositoryOwner":"%s"}\n' "$repo_name" "$commit_sha" "$repo_owner" > /tmp/plugin-info.json
+    mv plugin.json /tmp/orig-plugin.json
+    jq -s '.[0] * .[1]' /tmp/orig-plugin.json /tmp/plugin-info.json > plugin.json
 
-tar cf ../plugin.tar .
+    tar cf ../plugin.tar .
 
-curl -X POST 'https://node.windy.com/plugins/v1.0/upload' \
-     -H "x-windy-api-key: $WINDY_API_KEY" \
-     -F "plugin_archive=@../plugin.tar"
+    curl -X POST 'https://node.windy.com/plugins/v1.0/upload' \
+         -H "x-windy-api-key: $WINDY_API_KEY" \
+         -F "plugin_archive=@../plugin.tar"
+)
 


### PR DESCRIPTION
## Summary
- wrap plugin publishing steps in a subshell
- document WINDY_API_KEY requirement in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `bash -n publish_plugin.sh`

------
https://chatgpt.com/codex/tasks/task_e_6879f9122b88832cbfa91f1067d62e6a